### PR TITLE
Upgrading to the latest version of lodash to address vulnerbilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/NoumanSaleem/resvelope",
   "dependencies": {
-    "lodash": "^2.4.1",
+    "lodash": "^4.17.19",
     "statuses": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
npm audit from other apps that were using resvelope as a dependency were complaining of a vulnerability from the version of `lodash` that is used in this module.